### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,6 @@
 name: PR Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/maxveldink/quill/security/code-scanning/1](https://github.com/maxveldink/quill/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations, we can set the permissions to `contents: read` at the root level. This ensures that all jobs in the workflow inherit the least privilege required to complete their tasks.

The `permissions` block should be added after the `name` field at the top of the workflow file. This change will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
